### PR TITLE
ensure a map passed to strict contains no nil values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 .lein-repl-history
 .lein-plugins/
 .lein-failures
+.nrepl-port

--- a/README.md
+++ b/README.md
@@ -4,16 +4,23 @@ Utilities for a less tolerant Clojure.
 
 ## Usage
 
-This is still an experimental library. It is liable to change dramatically, or become unmaintained if I lose interest.
+This is still an experimental library. It is liable to change dramatically, or
+become unmaintained if I lose interest.
 
-If you want to use it, include it in your `project.clj` file to download it from Clojars:
+If you want to use it, include it in your `project.clj` file to download it
+from Clojars:
 
-    [strictly "0.1.0-SNAPSHOT"]
+    [strictly "0.2.0-SNAPSHOT"]
 
-Apply the `strict` function from the `map` namespace to create a map that throws an Exception if a key that does not exist is retrieved. This is in contract to Clojure's default behaviour of returning `nil` in such cases.
+Apply the `strict` function from the `map` namespace to create a map that
+throws an Exception if a key that does not exist is retrieved. This is in
+contrast to Clojure's default behaviour of returning `nil` in such cases.
 
-See [the tests](https://github.com/ctford/strictly/blob/master/test/strictly/map_test.clj) for example usages.
+The `strict` function will throw an Exception if the map contains nil values.
+
+See [the tests](https://github.com/ctford/strictly/blob/master/test/strictly/map_test.clj)
+for example usages.
 
 ## Licence
 
-Copyright © 2014 Chris Ford 
+Copyright © 2017 Chris Ford

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Less tolerant Clojure."
   :url "https://github.com/ctford/strictly"
   :license {:name "MIT License"}
-  :dependencies	[[org.clojure/clojure "1.8.0"]]
+  :dependencies	[[org.clojure/clojure "1.5.1"]]
   :profiles {:dev
              {:plugins [[lein-midje "3.2.1"] ]
               :dependencies [[midje "1.8.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Less tolerant Clojure."
   :url "https://github.com/ctford/strictly"
   :license {:name "MIT License"}
-  :dependencies	[[org.clojure/clojure "1.5.1"]]
+  :dependencies	[[org.clojure/clojure "1.8.0"]]
   :profiles {:dev
-             {:plugins [[lein-midje "3.1.3"] ]
-              :dependencies [[midje "1.6.3"]]}})
+             {:plugins [[lein-midje "3.2.1"] ]
+              :dependencies [[midje "1.8.3"]]}})

--- a/src/strictly/map.clj
+++ b/src/strictly/map.clj
@@ -59,18 +59,18 @@
             :otherwise
               v))))
 
-(defn branch?
+(defn ^:private branch?
   "Return true if the node coll contains a map as its key"
   [coll]
   (-> coll last map?))
 
-(defn children
+(defn ^:private children
   "Returns a sequence of node paths for children"
   [coll]
   (let [path (butlast coll) m (last coll) ]
     (map #(concat path %) m)))
 
-(defn node-paths
+(defn ^:private node-paths
   "Returns a sequence of node paths for a given map"
   [m]
   (->> m
@@ -78,15 +78,15 @@
        (tree-seq branch? children)
        (remove (comp map? last))))
 
-(defn invalid-values
+(defn ^:private invalid-values
   "Returns a lazy sequence of the items in a coll of node paths that
   contains nil values"
   [coll]
   (filter (comp nil? last) coll))
 
-(def error-msg (partial str "Invalid values: "))
+(def ^:private error-msg (partial str "Invalid values: "))
 
-(defn nil-value-check
+(defn ^:private nil-value-check
   "Throws an Exception if the map contains nil values"
   [m]
   (let [nodes (->> m node-paths invalid-values)]

--- a/src/strictly/map.clj
+++ b/src/strictly/map.clj
@@ -79,22 +79,24 @@
        (remove (comp map? last))))
 
 (defn ^:private invalid-values
-  "Returns a lazy sequence of the items in a coll of node paths that
-  contains nil values"
-  [coll]
-  (filter (comp nil? last) coll))
+  "Returns a lazy sequence of the items in a coll of node paths for which (pred
+  item) returns true"
+  [coll pred]
+  (filter (comp pred last) coll))
 
 (def ^:private error-msg (partial str "Invalid values: "))
 
-(defn ^:private nil-value-check
-  "Throws an Exception if the map contains nil values"
-  [m]
-  (let [nodes (->> m node-paths invalid-values)]
+(defn restriction
+  "Throws an Exception if the map contains values for which (pred item) returns true"
+  [m pred]
+  (let [nodes (-> m node-paths (invalid-values pred))]
     (if (-> nodes empty? not)
       (throw (new RuntimeException(error-msg (apply str nodes))))
       m)))
 
 (defn strict
   "Convert an ordinary map into one that throws an Exception if an
-  unknown key is requested. Ensures no nil values are defined"
-  [m] (-> m nil-value-check StrictMap.))
+  unknown key is requested. If pred is supplied an Exception will be thrown if
+  the map contains values for which (pred item) returns true"
+  ([m pred] (-> m (restriction pred) StrictMap.))
+  ([m] (-> m identity StrictMap.)))

--- a/src/strictly/map.clj
+++ b/src/strictly/map.clj
@@ -45,7 +45,7 @@
   (valAt [this k]
     (let [v (get inner k)]
       (cond (not (contains? inner k))
-              (throw (new RuntimeException  (str "Key '" k "' not found in strict map '" inner "'.")))  
+              (throw (new RuntimeException (str "Key '" k "' not found in strict map '" inner "'.")))
             (map? v)
               (StrictMap. v)
             :otherwise
@@ -53,12 +53,48 @@
   (valAt [this k default]
     (let [v (get inner k)]
       (cond (not (contains? inner k))
-              default 
+              default
             (map? v)
               (StrictMap. v)
             :otherwise
               v))))
-  
+
+(defn branch?
+  "Return true if the node coll contains a map as its key"
+  [coll]
+  (-> coll last map?))
+
+(defn children
+  "Returns a sequence of node paths for children"
+  [coll]
+  (let [path (butlast coll) m (last coll) ]
+    (map #(concat path %) m)))
+
+(defn node-paths
+  "Returns a sequence of node paths for a given map"
+  [m]
+  (->> m
+       (conj [])
+       (tree-seq branch? children)
+       (remove (comp map? last))))
+
+(defn invalid-values
+  "Returns a lazy sequence of the items in a coll of node paths that
+  contains nil values"
+  [coll]
+  (filter (comp nil? last) coll))
+
+(def error-msg (partial str "Invalid values: "))
+
+(defn nil-value-check
+  "Throws an Exception if the map contains nil values"
+  [m]
+  (let [nodes (->> m node-paths invalid-values)]
+    (if (-> nodes empty? not)
+      (throw (new RuntimeException(error-msg (apply str nodes))))
+      m)))
+
 (defn strict
-  "Convert an ordinary map into one that throws an Exception if an unknown key is requested." 
-  [m] (StrictMap. m))
+  "Convert an ordinary map into one that throws an Exception if an
+  unknown key is requested. Ensures no nil values are defined"
+  [m] (-> m nil-value-check StrictMap.))

--- a/test/strictly/map_test.clj
+++ b/test/strictly/map_test.clj
@@ -1,12 +1,6 @@
 (ns strictly.map-test
   (:require [midje.sweet :refer :all]
-            [strictly.map :refer [strict]]))
-
-(fact "Attempting to apply a strict map to a map containing nil values throws an exception"
-      (-> {:key :value} strict) => {:key :value}
-      (-> {:key :value :nested {:foo :bar}} strict) => {:key :value :nested {:foo :bar}}
-      (-> {:key nil} strict) => (throws RuntimeException)
-      (-> {:key :value :nested {:foo nil}} strict) => (throws RuntimeException))
+            [strictly.map :refer [strict restriction]]))
 
 (fact "Attempting to get a missing key from a strict map throws an exception."
       (-> {:key :value} strict :key) => :value
@@ -27,3 +21,10 @@
       (-> {:key :value} strict :foo) => (throws RuntimeException)
       (-> {:key :value :nested {:foo :bar}} strict :nested :baz) => (throws RuntimeException)
       (-> {:key :value :nested {:foo :bar}} strict (:nested :default) :baz) => (throws RuntimeException))
+
+(def stricter #(strict % nil?))
+(fact "Attempting to apply a strict map to a map containing nil values throws an exception"
+      (-> {:key :value} stricter) => {:key :value}
+      (-> {:key :value :nested {:foo :bar}} stricter) => {:key :value :nested {:foo :bar}}
+      (-> {:key nil} stricter) => (throws RuntimeException)
+      (-> {:key :value :nested {:foo nil}} stricter) => (throws RuntimeException))

--- a/test/strictly/map_test.clj
+++ b/test/strictly/map_test.clj
@@ -2,10 +2,16 @@
   (:require [midje.sweet :refer :all]
             [strictly.map :refer [strict]]))
 
+(fact "Attempting to apply a strict map to a map containing nil values throws an exception"
+      (-> {:key :value} strict) => {:key :value}
+      (-> {:key :value :nested {:foo :bar}} strict) => {:key :value :nested {:foo :bar}}
+      (-> {:key nil} strict) => (throws RuntimeException)
+      (-> {:key :value :nested {:foo nil}} strict) => (throws RuntimeException))
+
 (fact "Attempting to get a missing key from a strict map throws an exception."
       (-> {:key :value} strict :key) => :value
       (->> {:key :value} strict :key) => :value
-      (-> {:key :value} strict map?) => true 
+      (-> {:key :value} strict map?) => true
       (-> {:key :value} strict (:foo :default)) => :default
       (-> {:key :value} strict (apply [:key])) => :value
       (-> {:key :value} strict (get :key)) => :value
@@ -13,11 +19,11 @@
       (-> {:key :value} strict vals) => [:value]
       (-> {:key :value} strict keys) => [:key]
       (-> {:key :value} strict seq) => [[:key :value]]
-      (-> {:key :value} strict (= {:key :value})) => true 
+      (-> {:key :value} strict (= {:key :value})) => true
       (-> {:key :value} strict (conj {:foo :bar}) :foo) => :bar
       (-> {:key :value} strict (merge {:foo :bar}) :foo) => :bar
-      (-> {:key :value} strict (conj {:foo :bar}) :baz) => (throws RuntimeException) 
-      (-> {:key :value} strict (merge {:foo :bar}) :baz) => (throws RuntimeException) 
+      (-> {:key :value} strict (conj {:foo :bar}) :baz) => (throws RuntimeException)
+      (-> {:key :value} strict (merge {:foo :bar}) :baz) => (throws RuntimeException)
       (-> {:key :value} strict :foo) => (throws RuntimeException)
       (-> {:key :value :nested {:foo :bar}} strict :nested :baz) => (throws RuntimeException)
       (-> {:key :value :nested {:foo :bar}} strict (:nested :default) :baz) => (throws RuntimeException))


### PR DESCRIPTION
Increased levels of intolerance.... StrictMap will ensure that a map passed to the `strict` function contains no nil values.

Example use case: services are often configured at run time using configuration derived from structured data files (edn/yaml). These values are often populated during deployment.  If values are undefined behaviour is not always predictable.  Implementing a nil check ensures a service fails fast when values have been missed.

Interested in feedback on

- technical implementation, obvs
- function naming/conventions
- default behaviour; should nil value check be separated from the current functionality, optional composition, etc.
- should 'nil' be a configurable value? 

also, hi :)